### PR TITLE
update to appropriately write lists out to the vault secret object

### DIFF
--- a/src/test/java/io/ianferguson/vault/api/LogicalTest.java
+++ b/src/test/java/io/ianferguson/vault/api/LogicalTest.java
@@ -1,0 +1,28 @@
+package io.ianferguson.vault.api;
+
+import io.ianferguson.vault.VaultConfig;
+import io.ianferguson.vault.json.JsonObject;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LogicalTest extends TestCase {
+
+    public void testMapToJsonObject() {
+        Logical logical = new Logical(new VaultConfig());
+        Map<String, Object> data = new HashMap<>();
+        ArrayList testList = new ArrayList<>();
+        testList.add("value1");
+        testList.add(2);
+        testList.add(true);
+        data.put("ArrayValue", testList);
+        data.put("IntValue", 1);
+        data.put("BoolValue", false);
+        JsonObject jsonObject = logical.mapToJsonObject(data);
+
+        String expectedValue = "{\"BoolValue\":false,\"ArrayValue\":[\"value1\",2,true],\"IntValue\":1}";
+        assertTrue(jsonObject.toString().equals(expectedValue));
+    }
+}


### PR DESCRIPTION
Currently when you attempt to write out a list as a value into vault the writer will incorrectly format the list

example

```
{
   "key": "[value1, value2]"
}
```

This is fairly annoying and can be worked-around but it's not the behavior I was expecting. My work-around for this currently is just to use a comma-separated list but it's not ideal. Explicitly using a `JsonArray` object works but then I have issues when using jackson to convert objects and need special work-arounds just for writing a map to vault. 

This change will convert any list objects into`JsonArray` objects to make using this library a bit simpler and straight foward. I didn't see any tests for the `Logical` class so i made a quick unit test to show it's working. I've tested this locally for my user-case and it seems to do the trick.